### PR TITLE
Provide mechanism for injecting by interface

### DIFF
--- a/src/Domain/User/Update.ts
+++ b/src/Domain/User/Update.ts
@@ -1,11 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { User } from './User';
-import { UserRepository } from '../../Persistence/User/Repository';
+import { IUserRepository } from './IUserRepository';
+
+const UserRepo = () => Inject('UserRepo');
 
 @Injectable()
 export class Update {
 	constructor(
-		private readonly userRepository: UserRepository,
+		@UserRepo() private readonly userRepository: IUserRepository,
 	) {}
 
 	public async Update(userId: string, toUpdate: Partial<User>): Promise<void> {

--- a/src/Persistence/User/UserPersistenceProvider.ts
+++ b/src/Persistence/User/UserPersistenceProvider.ts
@@ -1,0 +1,7 @@
+import { Provider } from "@nestjs/common";
+import { UserRepository } from "./Repository";
+
+export const UserRepoProvider: Provider = {
+    provide: 'UserRepo',
+    useClass: UserRepository
+}

--- a/src/Persistence/User/UserRepositoryModule.ts
+++ b/src/Persistence/User/UserRepositoryModule.ts
@@ -3,10 +3,11 @@ import { MongooseModule } from '@nestjs/mongoose';
 
 import { UserRepository } from './Repository';
 import { UserSchema } from './UserEntity';
+import { UserRepoProvider } from './UserPersistenceProvider';
 
 @Module({
 	imports: [MongooseModule.forFeature([{ name: 'User', schema: UserSchema }])],
-	providers: [UserRepository],
-	exports: [UserRepository],
+	providers: [UserRepoProvider],
+	exports: [UserRepoProvider],
 })
 export class UserRepositoryModule {}


### PR DESCRIPTION
This PR is related to #1.

Example implementation how one can get rid of the dependency of the user domain (`Update.ts`) to the persistence part by using `IUserRepository` instead of `UserRepository` directly